### PR TITLE
Remove rust-embedded/hal team from maintainership

### DIFF
--- a/highfive/configs/rust-embedded/linux-embedded-hal.json
+++ b/highfive/configs/rust-embedded/linux-embedded-hal.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["rust-embedded/embedded-linux", "rust-embedded/hal"]
+        "all": ["rust-embedded/embedded-linux"]
     },
-    "new_pr_labels": ["S-waiting-on-review", "T-embedded-linux", "T-hal"]
+    "new_pr_labels": ["S-waiting-on-review", "T-embedded-linux"]
 }


### PR DESCRIPTION
By accident we had an unrelated team added as maintainers. https://github.com/rust-embedded/linux-embedded-hal/pull/16 rectifies it in the affected crate while https://github.com/rust-embedded/wg/pull/337 adjusts the documented state in the wg.