### PR TITLE
Add crates.io to highfive

### DIFF
--- a/highfive/configs/rust-lang/crates.io.json
+++ b/highfive/configs/rust-lang/crates.io.json
@@ -1,0 +1,8 @@
+{
+    "groups": {
+        "all": ["@sgrif", "@jtgeibel", "@carols10cents"]
+    },
+    "dirs": {},
+    "contributing": "https://github.com/rust-lang/crates.io/blob/master/docs/CONTRIBUTING.md",
+    "new_pr_labels": ["S-waiting-on-review"]
+}


### PR DESCRIPTION
This adds the [rust-lang/crates.io](https://github.com/rust-lang/crates.io) repository to highfive, with @sgrif, @jtgeibel and @carols10cents in the review rotation.