### PR TITLE
Assign ownership of the cross crate to the tools team

### DIFF
--- a/highfive/configs/rust-embedded/cross.json
+++ b/highfive/configs/rust-embedded/cross.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["@DylanDPC", "@jamesmunns"]
+        "all": ["rust-embedded/tools"]
     },
-    "new_pr_labels": ["S-waiting-on-review"]
+    "new_pr_labels": ["S-waiting-on-review", "T-tools"]
 }


### PR DESCRIPTION
No idea how we missed that single repository...

Signed-off-by: Daniel Egger <daniel@eggers-club.de>