### PR TITLE
Add smarnach to the crates.io rota.

### DIFF
--- a/highfive/configs/rust-lang/crates.io.json
+++ b/highfive/configs/rust-lang/crates.io.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["@sgrif", "@jtgeibel", "@carols10cents"]
+        "all": ["@sgrif", "@jtgeibel", "@carols10cents", "@smarnach"]
     },
     "dirs": {},
     "contributing": "https://github.com/rust-lang/crates.io/blob/master/docs/CONTRIBUTING.md",


### PR DESCRIPTION
This change should be merged after https://github.com/rust-lang/team/pull/150.