### PR TITLE
Add ecstatic-morse to compiler reviewers

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -1,7 +1,7 @@
 {
     "groups": {
         "all": [],
-        "compiler": ["@cramertj", "@eddyb", "@petrochenkov", "@estebank", "@varkor", "@matthewjasper", "@davidtwco"],
+        "compiler": ["@cramertj", "@eddyb", "@petrochenkov", "@estebank", "@varkor", "@matthewjasper", "@davidtwco", "@ecstatic-morse"],
         "syntax": ["@petrochenkov", "@eddyb"],
         "libs": ["@KodrAus", "@alexcrichton", "@sfackler", "@dtolnay", "@JoshTriplett", "@rkruppe", "@withoutboats", "@cramertj", "@shepmaster", "@Mark-Simulacrum", "@kennytm", "@LukasKalbertodt"],
         "infra-ci": ["@alexcrichton", "@Mark-Simulacrum", "@kennytm", "@pietroalbini"],


### PR DESCRIPTION
@nikomatsakis discussed adding me to the review queue when I first became a compiler contributor, but that never happened. I've experienced that reviewer time is often in short supply, so I'd like to ease the burden somewhat. I'm probably qualified to review small-scale changes to MIR, and I have a good idea of who to defer to when things are over my head.