### PR TITLE
Remove Alex Crichton from global core reviewers.

### DIFF
--- a/highfive/configs/_global.json
+++ b/highfive/configs/_global.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "core": ["@nikomatsakis", "@alexcrichton"],
+        "core": ["@nikomatsakis"],
         "crates": ["@alexcrichton"],
         "doc": ["@steveklabnik", "@GuillaumeGomez", "@QuietMisdreavus"],
         "rust-embedded/cortex-a": ["@andre-richter", "@parched", "@raw-bin", "@wizofe"],


### PR DESCRIPTION
In their post, Alex mentioned removing themselves from reviewer rotation on `rust-lang/rust`. However Alex is still getting pinged by highfive. I talked with Alex privately about being in the global core group of reviewers, and they said that it was a mistake. This PR fixes that.