### PR TITLE
Remove "doc" from cargo assignment.

### DIFF
--- a/highfive/configs/rust-lang/cargo.json
+++ b/highfive/configs/rust-lang/cargo.json
@@ -2,9 +2,6 @@
     "groups": {
         "all": ["@alexcrichton", "@ehuss", "@Eh2406"]
     },
-    "dirs": {
-        "src/doc": ["doc"]
-    },
     "contributing": "https://github.com/rust-lang/cargo/blob/master/CONTRIBUTING.md",
     "new_pr_labels": ["S-waiting-on-review"]
 }


### PR DESCRIPTION
In practice it is never used, and tends to get some false positives.
cc @rust-lang/cargo