### PR TITLE
crates.io: Add "ember" team and assign corresponding `dir` patterns

### DIFF
--- a/highfive/configs/rust-lang/crates.io.json
+++ b/highfive/configs/rust-lang/crates.io.json
@@ -1,8 +1,16 @@
 {
     "groups": {
-        "all": ["@sgrif", "@jtgeibel", "@carols10cents", "@smarnach"]
+        "all": ["@sgrif", "@jtgeibel", "@carols10cents", "@smarnach"],
+        "ember": ["@locks", "@Turbo87"]
     },
-    "dirs": {},
+    "dirs": {
+        "package.json": ["ember"],
+        "package-lock.json": ["ember"],
+        "app": ["ember"],
+        "mirage": ["ember"],
+        "public": ["ember"],
+        "tests": ["ember"]
+    },
     "contributing": "https://github.com/rust-lang/crates.io/blob/master/docs/CONTRIBUTING.md",
     "new_pr_labels": ["S-waiting-on-review"]
 }


### PR DESCRIPTION
This PR adds an "ember" team to the config for the crates.io project, which is responsible for the Ember.js-based web frontend. I've also added the corresponding folder and files to the `dir` config, so that the people on that team are automatically assigned.

/cc @pietroalbini @locks