### PR TITLE
Do not assign cramertj as a reviewer to compiler PRs

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -1,7 +1,7 @@
 {
     "groups": {
         "all": [],
-        "compiler": ["@cramertj", "@eddyb", "@petrochenkov", "@estebank", "@varkor", "@matthewjasper", "@davidtwco", "@ecstatic-morse"],
+        "compiler": ["@eddyb", "@petrochenkov", "@estebank", "@varkor", "@matthewjasper", "@davidtwco", "@ecstatic-morse"],
         "syntax": ["@petrochenkov", "@eddyb"],
         "libs": ["@sfackler", "@dtolnay", "@JoshTriplett", "@hanna-kruppe", "@withoutboats", "@cramertj", "@shepmaster", "@Mark-Simulacrum", "@kennytm", "@LukasKalbertodt"],
         "infra-ci": ["@Mark-Simulacrum", "@kennytm", "@pietroalbini"],


### PR DESCRIPTION
cramertj was moved to compiler team alumni in https://github.com/rust-lang/team/pull/311, but compiler PRs are still assigned to him and may wait for multiple weeks before getting reassigned.

cc @cramertj
r? @nikomatsakis 