### PR TITLE
Remove outdated `run-doc-ui` commands

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -50,16 +50,11 @@
     "mentions": {
         "src/librustdoc/html/static": {
             "message": "Some changes occurred in HTML/CSS/JS.",
-            "command": "@highfive: run-doc-ui",
             "reviewers": ["@GuillaumeGomez"]
         },
         "src/librustdoc/html/static/themes": {
             "message": "Some changes occurred in HTML/CSS themes.",
-            "command": "@highfive: run-doc-ui",
             "reviewers": ["@GuillaumeGomez"]
-        },
-        "src/librustdoc/": {
-            "command": "@highfive: run-doc-ui"
         },
         "error_codes.rs": {
             "message": "Some changes occurred in diagnostic error codes",


### PR DESCRIPTION
This command never worked (confirmed with @GuillaumeGomez on Discord) and we can remove it anyway.
I suspect this causes failures when highfive do labeling on rustdoc-related PRs.

r? @Mark-Simulacrum or @pietroalbini
