### PR TITLE
Delete blog.rust-lang.org.json

### DIFF
--- a/highfive/configs/rust-lang/blog.rust-lang.org.json
+++ b/highfive/configs/rust-lang/blog.rust-lang.org.json
@@ -1,8 +1,0 @@
-{
-    "groups": {
-        "all": ["core"]
-    },
-    "expected_branch": "master",
-    "dirs": {
-    }
-}


### PR DESCRIPTION
Disable highfive on the blog while we try out `CODEOWNERS`