### PR TITLE
Add configuration for rust-embedded/nb repository

### DIFF
--- a/highfive/configs/rust-embedded/nb.json
+++ b/highfive/configs/rust-embedded/nb.json
@@ -1,0 +1,6 @@
+{
+    "groups": {
+        "all": ["rust-embedded/hal"]
+    },
+    "new_pr_labels": ["S-waiting-on-review", "T-hal"]
+}


### PR DESCRIPTION
[`nb`](https://github.com/rust-embedded/nb/) is now managed by the rust-embedded/hal team.