### PR TITLE
Update default contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ blank.
 
 `contributing` specifies the contribution guide link in the message which
 welcomes new contributors to the repository. If `contributing` is not
-present, the [Rust contributing.md][rustcontrib] will be linked instead. 
+present, [the contributing chapter of the rustc-dev-guide][rustcontrib]
+will be linked instead.
 
 If PRs should be filed against a branch other than `master`, specify the
 correct destination in the `expected_branch` field. If `expected_branch` is
@@ -179,7 +180,7 @@ Here are some details to be aware of:
 - Highfive ignores comments from the integration user near the top of
   `new_commment` in [highfive/newpr.py](/highfive/newpr.py).
 
-[rustcontrib]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md 
+[rustcontrib]: https://rustc-dev-guide.rust-lang.org/contributing.html
 
 Docker
 ------

--- a/highfive/configs/rust-lang/libc.json
+++ b/highfive/configs/rust-lang/libc.json
@@ -3,5 +3,6 @@
         "all": ["@JohnTitor"]
     },
     "dirs": {
-    }
+    },
+    "contributing": "https://github.com/rust-lang/libc/blob/master/CONTRIBUTING.md"
 }

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -185,7 +185,7 @@ class HighfiveHandler(object):
         # Default to the Rust contribution guide if "contributing" wasn't set
         link = self.repo_config.get('contributing')
         if not link:
-            link = "https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md"
+            link = "https://rustc-dev-guide.rust-lang.org/contributing.html"
         return raw_welcome % (text, link)
 
     def review_msg(self, reviewer, submitter):

--- a/highfive/tests/test_integration_tests.py
+++ b/highfive/tests/test_integration_tests.py
@@ -103,7 +103,7 @@ class TestNewPr(object):
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
                     {
-                        'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nIf any changes to this PR are deemed necessary, please add them as extra commits. This ensures that the reviewer can see what has changed since they last reviewed the code. Due to the way GitHub handles out-of-date commits, this should also make it reasonably obvious what issues have or haven't been addressed. Large or tricky changes may require several passes of review and changes.\n\nPlease see [the contribution instructions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md) for more information.\n"}
+                        'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nIf any changes to this PR are deemed necessary, please add them as extra commits. This ensures that the reviewer can see what has changed since they last reviewed the code. Due to the way GitHub handles out-of-date commits, this should also make it reasonably obvious what issues have or haven't been addressed. Large or tricky changes may require several passes of review and changes.\n\nPlease see [the contribution instructions](https://rustc-dev-guide.rust-lang.org/contributing.html) for more information.\n"}
                 ),
                 {'body': {}},
             ),
@@ -145,7 +145,7 @@ class TestNewPr(object):
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
                     {
-                        'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nIf any changes to this PR are deemed necessary, please add them as extra commits. This ensures that the reviewer can see what has changed since they last reviewed the code. Due to the way GitHub handles out-of-date commits, this should also make it reasonably obvious what issues have or haven't been addressed. Large or tricky changes may require several passes of review and changes.\n\nPlease see [the contribution instructions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md) for more information.\n"}
+                        'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nIf any changes to this PR are deemed necessary, please add them as extra commits. This ensures that the reviewer can see what has changed since they last reviewed the code. Due to the way GitHub handles out-of-date commits, this should also make it reasonably obvious what issues have or haven't been addressed. Large or tricky changes may require several passes of review and changes.\n\nPlease see [the contribution instructions](https://rustc-dev-guide.rust-lang.org/contributing.html) for more information.\n"}
                 ),
                 {'body': {}},
             ),

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -121,14 +121,14 @@ Please see [the contribution instructions](%s) for more information.
         handler = HighfiveHandlerMock(Payload({})).handler
         assert handler.welcome_msg(None) == base_msg % (
             '@nrc (NB. this repo may be misconfigured)',
-            'https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md'
+            'https://rustc-dev-guide.rust-lang.org/contributing.html'
         )
 
         # Has reviewer, no config contributing link.
         handler = HighfiveHandlerMock(Payload({})).handler
         assert handler.welcome_msg('userA') == base_msg % (
             '@userA (or someone else)',
-            'https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md'
+            'https://rustc-dev-guide.rust-lang.org/contributing.html'
         )
 
         # No reviewer, has config contributing link.


### PR DESCRIPTION
The previous link is outdated and it now lives on the rustc-dev-guide.