### PR TITLE
rust-lang/rust: Assign reviews to all active compiler team members and contributors

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -1,9 +1,12 @@
 {
     "groups": {
         "all": [],
-        "compiler-team": ["@eddyb", "@estebank", "@matthewjasper",
-                          "@oli-obk", "@petrochenkov", "@varkor"],
-        "compiler-team-contributors": ["@davidtwco", "@ecstatic-morse", "@lcnr"],
+        "compiler-team": ["@eddyb", "@estebank", "@matthewjasper", "@nagisa", "@nikomatsakis",
+                          "@oli-obk", "@petrochenkov", "@pnkfelix", "@varkor", "@wesleywiser"],
+        "compiler-team-contributors": ["@Aaron1011", "@davidtwco", "@ecstatic-morse",
+                                       "@jonas-schievink", "@lcnr", "@Mark-Simulacrum",
+                                       "@nikic", "@nnethercote", "@RalfJung",
+                                       "@spastorino", "@tmandry", "@Xanewok"],
         "libs": ["@sfackler", "@dtolnay", "@JoshTriplett", "@hanna-kruppe",
                  "@withoutboats", "@cramertj", "@shepmaster", "@Mark-Simulacrum",
                  "@kennytm", "@LukasKalbertodt", "@KodrAus"],


### PR DESCRIPTION
Implement the suggestion from https://github.com/rust-lang/highfive/pull/266#issuecomment-647040858 and increases the number of assignable people from 9 to 22.

Highfive uses a check based on `git blame` to increase the chance of the selected reviewer being familiar with the code.

Excluded from the list:
- matklad, flodiebold - work on rust-analyzer but not rustc
- lqd - works on polonius but not rustc, also inactive?
- zackmdavis, scalexm - inactive

r? @nikomatsakis 