### PR TITLE
Update rust.json for compiler/rustc_llvm

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -30,7 +30,7 @@
         "library/test":              ["libs"],
         "src/llvm-project":         ["@cuviper"],
         "compiler":                ["compiler-team", "compiler-team-contributors"],
-        "src/rustllvm":             ["@cuviper"],
+        "compiler/rustc_llvm":      ["@cuviper"],
         "src/stage0.txt":           ["@Mark-Simulacrum"],
         "library/stdarch":              ["libs"],
         "src/tools/cargo":          ["@ehuss", "@joshtriplett"],


### PR DESCRIPTION
`src/rustllvm` and `src/librustc_llvm` moved to `compiler/rustc_llvm` in https://github.com/rust-lang/rust/pull/74787.