### PR TITLE
remove yaahc from clippy review rotation

### DIFF
--- a/highfive/configs/rust-lang/rust-clippy.json
+++ b/highfive/configs/rust-lang/rust-clippy.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["@ebroto", "@flip1995", "@Manishearth", "@matthiaskrgr", "@phansch", "@yaahc"]
+        "all": ["@ebroto", "@flip1995", "@Manishearth", "@matthiaskrgr", "@phansch"]
     },
     "dirs": {
         ".github": ["@flip1995"],


### PR DESCRIPTION
going to focus on the error handling project group for the time being