### PR TITLE
Configure `new_pr_labels` for libc

### DIFF
--- a/highfive/configs/rust-lang/libc.json
+++ b/highfive/configs/rust-lang/libc.json
@@ -4,5 +4,6 @@
     },
     "dirs": {
     },
-    "contributing": "https://github.com/rust-lang/libc/blob/master/CONTRIBUTING.md"
+    "contributing": "https://github.com/rust-lang/libc/blob/master/CONTRIBUTING.md",
+    "new_pr_labels": ["S-waiting-on-review"]
 }


### PR DESCRIPTION
We've added some status labels just like rust-lang/rust to make reviews easier. This makes our triage easier as well.