### PR TITLE
Add m-ou-se to libs review rotation

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -6,7 +6,7 @@
         "compiler-team-contributors": ["@davidtwco", "@ecstatic-morse", "@lcnr"],
         "libs": ["@sfackler", "@dtolnay", "@JoshTriplett",
                  "@withoutboats", "@cramertj", "@shepmaster", "@Mark-Simulacrum",
-                 "@kennytm", "@LukasKalbertodt", "@KodrAus"],
+                 "@kennytm", "@LukasKalbertodt", "@KodrAus", "@m-ou-se"],
         "infra-ci": ["@Mark-Simulacrum", "@kennytm", "@pietroalbini"],
         "rustdoc": ["@jyn514", "@GuillaumeGomez", "@ollie27"]
     },


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/team/pull/457.
@m-ou-se