### PR TITLE
Remove KodrAus from highfive rotation for a bit

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -6,7 +6,7 @@
         "compiler-team-contributors": ["@davidtwco", "@ecstatic-morse", "@lcnr"],
         "libs": ["@sfackler", "@dtolnay", "@JoshTriplett",
                  "@withoutboats", "@cramertj", "@shepmaster", "@Mark-Simulacrum",
-                 "@kennytm", "@KodrAus", "@m-ou-se"],
+                 "@kennytm", "@m-ou-se"],
         "infra-ci": ["@Mark-Simulacrum", "@kennytm", "@pietroalbini"],
         "rustdoc": ["@jyn514", "@GuillaumeGomez", "@ollie27"]
     },


### PR DESCRIPTION
I’m going to try focusing purely on organizational things for Libs for a bit so will pull myself out of the rotation for now.

I’ll finish working through my current backlog of PRs though!