### PR TITLE
rust_highfive -> rust-highfive

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -31,7 +31,7 @@ warning_summary = ':warning: **Warning** :warning:\n\n%s'
 submodule_warning_msg = 'These commits modify **submodules**.'
 surprise_branch_warning = "Pull requests are usually filed against the %s branch for this repo, but this one is against %s. Please double check that you specified the right target!"
 
-review_with_reviewer = 'r? @%s\n\n(rust_highfive has picked a reviewer for you, use r? to override)'
+review_with_reviewer = 'r? @%s\n\n(rust-highfive has picked a reviewer for you, use r? to override)'
 review_without_reviewer = '@%s: no appropriate reviewer found, use r? to override'
 
 reviewer_re = re.compile("\\b[rR]\?[:\- ]*@([a-zA-Z0-9\-]+)")

--- a/highfive/tests/test_integration_tests.py
+++ b/highfive/tests/test_integration_tests.py
@@ -185,7 +185,7 @@ class TestNewPr(object):
             (
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
-                    {'body': 'r? @nrc\n\n(rust_highfive has picked a reviewer for you, use r? to override)'}
+                    {'body': 'r? @nrc\n\n(rust-highfive has picked a reviewer for you, use r? to override)'}
                 ),
                 {'body': {}},
             ),
@@ -229,7 +229,7 @@ class TestNewPr(object):
             (
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
-                    {'body': 'r? @nrc\n\n(rust_highfive has picked a reviewer for you, use r? to override)'}
+                    {'body': 'r? @nrc\n\n(rust-highfive has picked a reviewer for you, use r? to override)'}
                 ),
                 {'body': {}},
             ),

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -157,7 +157,7 @@ Please see [the contribution instructions](%s) for more information.
 
         # Has reviewer.
         assert handler.review_msg('userA', 'userB') == \
-               'r? @userA\n\n(rust_highfive has picked a reviewer for you, use r? to override)'
+               'r? @userA\n\n(rust-highfive has picked a reviewer for you, use r? to override)'
 
     @mock.patch('os.path.dirname')
     def test_load_json_file(self, mock_dirname):


### PR DESCRIPTION
The name of the bot account is `rust-highfive`, so I changed the name
used in the comment to use a hyphen instead of an underscore.
