### PR TITLE
Update the crates.io roaster

### DIFF
--- a/highfive/configs/rust-lang/crates.io.json
+++ b/highfive/configs/rust-lang/crates.io.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["@sgrif", "@jtgeibel", "@carols10cents", "@smarnach"],
+        "all": ["@jtgeibel", "@carols10cents", "@smarnach"],
         "ember": ["@locks", "@Turbo87"]
     },
     "dirs": {
@@ -9,7 +9,9 @@
         "app": ["ember"],
         "mirage": ["ember"],
         "public": ["ember"],
-        "tests": ["ember"]
+        "tests": ["ember"],
+        "src": ["all", "@JohnTitor"],
+        "Cargo.lock": ["@JohnTitor"]
     },
     "contributing": "https://github.com/rust-lang/crates.io/blob/master/docs/CONTRIBUTING.md",
     "new_pr_labels": ["S-waiting-on-review"]


### PR DESCRIPTION
- Remove `sgrif` from the roaster in favor of https://github.com/rust-lang/team/pull/482
- Assign `JohnTitor` in some paths

So, highfive currently tries to assign `sgrif` but I assume we shouldn't in favor of https://github.com/rust-lang/team/pull/482. And add me to the roaster in some paths, I could review Rust and their deps stuff.

cc @jtgeibel to check and @pietroalbini to check/merge.