### PR TITLE
Don't use startswith when comparing mentions paths.

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -340,7 +340,11 @@ class HighfiveHandler(object):
                         cur_dir = None
                     if len(full_dir) > 0:
                         for entry in mentions:
-                            if full_dir.startswith(entry):
+                            # Check if this entry is a prefix
+                            eparts = entry.split("/")
+                            if (len(eparts) <= len(parts) and
+                                all(a==b for a,b in zip(parts, eparts))
+                            ):
                                 to_mention.add(entry)
                             elif entry.endswith('.rs') and full_dir.endswith(entry):
                                 to_mention.add(entry)

--- a/highfive/tests/fakes.py
+++ b/highfive/tests/fakes.py
@@ -48,6 +48,24 @@ def get_repo_configs():
             "groups": {"all": []},
             "dirs": {},
         },
+        'mentions': {
+            "groups": {"all": []},
+            "dirs": {"compiler": ["@pnkfelix"]},
+            "mentions": {
+                "src/tools/cargo": {
+                    "message": "this should not match startswith",
+                    "reviewers": ["@ehuss"],
+                },
+                "error_codes.rs": {
+                    "message": "bare .rs file should match endswith",
+                    "reviewers": ["@GuillaumeGomez"],
+                },
+                "compiler/rustc": {
+                    "message": "directory should match all files within",
+                    "reviewers": ["@pnkfelix"],
+                }
+            }
+        }
     }
 
 

--- a/highfive/tests/fakes/mentions.diff
+++ b/highfive/tests/fakes/mentions.diff
@@ -1,0 +1,34 @@
+diff --git a/compiler/rustc/src/main.rs b/compiler/rustc/src/main.rs
+index 6bc5aa6382c..4fc3e397508 100644
+--- a/compiler/rustc/src/main.rs
++++ b/compiler/rustc/src/main.rs
+@@ -1,3 +1,4 @@
++// Hello!
+ fn main() {
+     // Pull in jemalloc when enabled.
+     //
+diff --git a/compiler/rustc_error_codes/src/error_codes.rs b/compiler/rustc_error_codes/src/error_codes.rs
+index 636c37142ad..2172d8eaec9 100644
+--- a/compiler/rustc_error_codes/src/error_codes.rs
++++ b/compiler/rustc_error_codes/src/error_codes.rs
+@@ -463,6 +463,7 @@
+ E0777: include_str!("./error_codes/E0777.md"),
+ E0778: include_str!("./error_codes/E0778.md"),
+ E0779: include_str!("./error_codes/E0779.md"),
++E0779: include_str!("./error_codes/E0780.md"),
+ ;
+ //  E0006, // merged with E0005
+ //  E0008, // cannot bind by-move into a pattern guard
+diff --git a/src/tools/cargotest/main.rs b/src/tools/cargotest/main.rs
+index 8aabe077cf1..0a6bac48ebb 100644
+--- a/src/tools/cargotest/main.rs
++++ b/src/tools/cargotest/main.rs
+@@ -36,7 +36,7 @@ struct Test {
+     Test {
+         name: "xsv",
+         repo: "https://github.com/BurntSushi/xsv",
+-        sha: "66956b6bfd62d6ac767a6b6499c982eae20a2c9f",
++        sha: "3de6c04269a7d315f7e9864b9013451cd9580a08",
+         lock: None,
+         packages: &[],
+     },


### PR DESCRIPTION
This changes it so that paths in "mentions" are compared using full path components instead of a simple string compare. This should fix "src/tools/cargo" from matching "src/tools/cargotest".  AFAIK, none of the [current mentions](https://github.com/rust-lang/highfive/blob/7b2463842ed52e05b11dada10de0007b17919b3f/highfive/configs/rust-lang/rust.json#L47-L72) are relying on this behavior.

I added a test, though in the process needed to change some things because the existing test infrastructure didn't properly support "mentions".

Fixes #253
