### PR TITLE
Remove ecstatic morse from reviewer auto rotation

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -2,8 +2,8 @@
     "groups": {
         "all": [],
         "compiler-team": ["@estebank", "@matthewjasper",
-                          "@oli-obk", "@petrochenkov", "@varkor"],
-        "compiler-team-contributors": ["@davidtwco", "@ecstatic-morse", "@lcnr"],
+                          "@oli-obk", "@petrochenkov", "@varkor", "@lcnr"],
+        "compiler-team-contributors": ["@davidtwco"],
         "libs": ["@sfackler", "@dtolnay", "@JoshTriplett",
                  "@withoutboats", "@cramertj", "@shepmaster", "@Mark-Simulacrum",
                  "@kennytm", "@m-ou-se"],


### PR DESCRIPTION
cc @ecstatic-morse feel free to add yourself at any point when you want to have PRs assigned to yourself again

I also moved @lcnr to the compiler team (not sure this has any visible effect :laughing:)