### PR TITLE
Warn on updates to compiler targets

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -29,6 +29,7 @@ Please see [the contribution instructions](%s) for more information.
 
 warning_summary = ':warning: **Warning** :warning:\n\n%s'
 submodule_warning_msg = 'These commits modify **submodules**.'
+targets_warning_msg = 'These commits modify **compiler targets**. ([Target Support Tier Policy](https://github.com/joshtriplett/rfcs/blob/target-tier-policy/text/0000-target-tier-policy.md))'
 surprise_branch_warning = "Pull requests are usually filed against the %s branch for this repo, but this one is against %s. Please double check that you specified the right target!"
 
 review_with_reviewer = 'r? @%s\n\n(rust-highfive has picked a reviewer for you, use r? to override)'
@@ -36,6 +37,7 @@ review_without_reviewer = '@%s: no appropriate reviewer found, use r? to overrid
 
 reviewer_re = re.compile("\\b[rR]\?[:\- ]*@([a-zA-Z0-9\-]+)")
 submodule_re = re.compile(".*\+Subproject\scommit\s.*", re.DOTALL | re.MULTILINE)
+target_re = re.compile("^[+-]{3} [ab]/compiler/rustc_target/src/spec/", re.MULTILINE)
 
 rustaceans_api_url = "http://www.ncameron.org/rustaceans/user?username={username}"
 
@@ -84,6 +86,9 @@ class HighfiveHandler(object):
 
     def modifies_submodule(self, diff):
         return submodule_re.match(diff)
+
+    def modifies_targets(self, diff):
+        return target_re.search(diff)
 
     def api_req(self, method, url, data=None, media_type=None):
         data = None if not data else json.dumps(data).encode("utf-8")
@@ -163,6 +168,9 @@ class HighfiveHandler(object):
 
         if self.modifies_submodule(diff):
             warnings.append(submodule_warning_msg)
+
+        if self.modifies_targets(diff):
+            warnings.append(targets_warning_msg)
 
         if warnings:
             self.post_comment(warning_summary % '\n'.join(map(lambda x: '* ' + x, warnings)), owner, repo, issue)

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -29,7 +29,7 @@ Please see [the contribution instructions](%s) for more information.
 
 warning_summary = ':warning: **Warning** :warning:\n\n%s'
 submodule_warning_msg = 'These commits modify **submodules**.'
-targets_warning_msg = 'These commits modify **compiler targets**. ([Target Support Tier Policy](https://github.com/joshtriplett/rfcs/blob/target-tier-policy/text/0000-target-tier-policy.md))'
+targets_warning_msg = 'These commits modify **compiler targets**. (See the [Target Tier Policy](https://doc.rust-lang.org/nightly/rustc/target-tier-policy.html).)'
 surprise_branch_warning = "Pull requests are usually filed against the %s branch for this repo, but this one is against %s. Please double check that you specified the right target!"
 
 review_with_reviewer = 'r? @%s\n\n(rust-highfive has picked a reviewer for you, use r? to override)'

--- a/highfive/tests/fakes/target.diff
+++ b/highfive/tests/fakes/target.diff
@@ -1,0 +1,12 @@
+diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
+index 039e9a8b274..43a8c5e415d 100644
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -680,6 +680,7 @@ fn to_json(&self) -> Json {
+     ("aarch64-linux-android", aarch64_linux_android),
+ 
+     ("x86_64-linux-kernel", x86_64_linux_kernel),
++    ("x86_64-freebsd-kernel", x86_64_freebsd_kernel),
+ 
+     ("aarch64-unknown-freebsd", aarch64_unknown_freebsd),
+     ("armv6-unknown-freebsd", armv6_unknown_freebsd),

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -754,7 +754,7 @@ class TestPostWarnings(TestNewPR):
 
 * Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!
 * These commits modify **submodules**.
-* These commits modify **compiler targets**. ([Target Support Tier Policy](https://github.com/joshtriplett/rfcs/blob/target-tier-policy/text/0000-target-tier-policy.md))"""
+* These commits modify **compiler targets**. (See the [Target Tier Policy](https://doc.rust-lang.org/nightly/rustc/target-tier-policy.html).)"""
         self.mocks['post_comment'].assert_called_with(
             expected_warning, self.owner, self.repo, self.issue
         )

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -284,6 +284,20 @@ Please see [the contribution instructions](%s) for more information.
         normal_diff = load_fake('normal.diff')
         assert not handler.modifies_submodule(normal_diff)
 
+        targets_diff = load_fake('target.diff')
+        assert not handler.modifies_submodule(targets_diff)
+
+    def test_targets(self):
+        handler = HighfiveHandlerMock(Payload({})).handler
+        targets_diff = load_fake('target.diff')
+        assert handler.modifies_targets(targets_diff)
+
+        normal_diff = load_fake('normal.diff')
+        assert not handler.modifies_targets(normal_diff)
+
+        submodule_diff = load_fake('submodule.diff')
+        assert not handler.modifies_targets(submodule_diff)
+
     def test_expected_branch_default_expected_no_match(self):
         payload = Payload(
             {'pull_request': {'base': {'label': 'repo-owner:dev'}}}
@@ -631,6 +645,7 @@ class TestPostWarnings(TestNewPR):
         cls.mocks = patcherize((
             ('unexpected_branch', 'highfive.newpr.HighfiveHandler.unexpected_branch'),
             ('modifies_submodule', 'highfive.newpr.HighfiveHandler.modifies_submodule'),
+            ('modifies_targets', 'highfive.newpr.HighfiveHandler.modifies_targets'),
             ('post_comment', 'highfive.newpr.HighfiveHandler.post_comment'),
         ))
 
@@ -654,11 +669,13 @@ class TestPostWarnings(TestNewPR):
     def test_no_warnings(self):
         self.mocks['unexpected_branch'].return_value = False
         self.mocks['modifies_submodule'].return_value = False
+        self.mocks['modifies_targets'].return_value = False
 
         self.post_warnings()
 
         self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_targets'].assert_called_with(self.diff)
         self.mocks['post_comment'].assert_not_called()
 
     def test_unexpected_branch(self):
@@ -666,11 +683,13 @@ class TestPostWarnings(TestNewPR):
             'master', 'something-else'
         )
         self.mocks['modifies_submodule'].return_value = False
+        self.mocks['modifies_targets'].return_value = False
 
         self.post_warnings()
 
         self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_targets'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:
 
@@ -682,11 +701,13 @@ class TestPostWarnings(TestNewPR):
     def test_modifies_submodule(self):
         self.mocks['unexpected_branch'].return_value = False
         self.mocks['modifies_submodule'].return_value = True
+        self.mocks['modifies_targets'].return_value = False
 
         self.post_warnings()
 
         self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_targets'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:
 
@@ -700,16 +721,40 @@ class TestPostWarnings(TestNewPR):
             'master', 'something-else'
         )
         self.mocks['modifies_submodule'].return_value = True
+        self.mocks['modifies_targets'].return_value = False
 
         self.post_warnings()
 
         self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_targets'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:
 
 * Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!
 * These commits modify **submodules**."""
+        self.mocks['post_comment'].assert_called_with(
+            expected_warning, self.owner, self.repo, self.issue
+        )
+
+    def test_unexpected_branch_modifies_submodule_and_targets(self):
+        self.mocks['unexpected_branch'].return_value = (
+            'master', 'something-else'
+        )
+        self.mocks['modifies_submodule'].return_value = True
+        self.mocks['modifies_targets'].return_value = True
+
+        self.post_warnings()
+
+        self.mocks['unexpected_branch'].assert_called_once_with()
+        self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_targets'].assert_called_with(self.diff)
+
+        expected_warning = """:warning: **Warning** :warning:
+
+* Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!
+* These commits modify **submodules**.
+* These commits modify **compiler targets**. ([Target Support Tier Policy](https://github.com/joshtriplett/rfcs/blob/target-tier-policy/text/0000-target-tier-policy.md))"""
         self.mocks['post_comment'].assert_called_with(
             expected_warning, self.owner, self.repo, self.issue
         )


### PR DESCRIPTION
Closes #310.

This was simpler than I thought, but also has some reductions:

* I did not know that multi-line messages were discouraged by the structure of the code. I decided to work within that, rather than refactor it just for this new message.
* Given the pattern match I put in, I decided not to tag release notes to avoid false positives. I am not sure if, for example, some LLVM changes would trigger this warning as well.

This is ready for review, but am putting it in draft because the RFC I'm linking to is not yet merged. Once that happens (it seems to be a matter of when at this point), I will update it with the proper link on The Forge.