### PR TITLE
Remove myself from reviewer rotation

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -4,7 +4,6 @@
         "compiler-team": [
             "@estebank",
             "@matthewjasper",
-            "@oli-obk",
             "@petrochenkov",
             "@varkor",
             "@lcnr"


### PR DESCRIPTION
While I'm still around for a few weeks, taking on reviewing of new PRs is probably not a good idea if I know I'm going to disappear. I'll re-add myself in summer