### PR TITLE
Mention the clippy team when the clippy directory is touched

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -103,6 +103,10 @@
             "message": "Some changes occurred in src/tools/rustfmt.",
             "reviewers": ["@calebcartwright"]
         }
+        "src/tools/clippy": {
+            "message": "Some changes occurred in src/tools/clippy.",
+            "reviewers": ["@rust-lang/clippy"]
+        }
     },
     "new_pr_labels": ["S-waiting-on-review"]
 }

--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -102,7 +102,7 @@
         "src/tools/rustfmt": {
             "message": "Some changes occurred in src/tools/rustfmt.",
             "reviewers": ["@calebcartwright"]
-        }
+        },
         "src/tools/clippy": {
             "message": "Some changes occurred in src/tools/clippy.",
             "reviewers": ["@rust-lang/clippy"]


### PR DESCRIPTION
cc @rust-lang/clippy is this going to overwhelm us with uninteresting pings? Or will this be helpful in tracking changes to clippy happening just from within rustc?