### PR TITLE
Ping eddyb on apfloat changes

### DIFF
--- a/highfive/tests/fakes/apfloat.diff
+++ b/highfive/tests/fakes/apfloat.diff
@@ -1,0 +1,12 @@
+diff --git a/compiler/rustc_apfloat/src/lib.rs b/compiler/rustc_apfloat/src/lib.rs
+index 4a845fcb691..6e7b2c6fc46 100644
+--- a/compiler/rustc_apfloat/src/lib.rs
++++ b/compiler/rustc_apfloat/src/lib.rs
+@@ -102,7 +102,6 @@ macro_rules! unpack {
+ /// Category of internally-represented number.
+ #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+ pub enum Category {
+-    Infinity,
+     NaN,
+     Normal,
+     Zero,

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -284,6 +284,20 @@ Please see [the contribution instructions](%s) for more information.
         normal_diff = load_fake('normal.diff')
         assert not handler.modifies_submodule(normal_diff)
 
+        apfloat_diff = load_fake('apfloat.diff')
+        assert not handler.modifies_submodule(apfloat_diff)
+
+    def test_apfloat(self):
+        handler = HighfiveHandlerMock(Payload({})).handler
+        apfloat_diff = load_fake('apfloat.diff')
+        assert handler.modifies_apfloat(apfloat_diff)
+
+        normal_diff = load_fake('normal.diff')
+        assert not handler.modifies_apfloat(normal_diff)
+
+        submodule_diff = load_fake('submodule.diff')
+        assert not handler.modifies_apfloat(submodule_diff)
+
     def test_expected_branch_default_expected_no_match(self):
         payload = Payload(
             {'pull_request': {'base': {'label': 'repo-owner:dev'}}}
@@ -631,6 +645,7 @@ class TestPostWarnings(TestNewPR):
         cls.mocks = patcherize((
             ('unexpected_branch', 'highfive.newpr.HighfiveHandler.unexpected_branch'),
             ('modifies_submodule', 'highfive.newpr.HighfiveHandler.modifies_submodule'),
+            ('modifies_apfloat', 'highfive.newpr.HighfiveHandler.modifies_apfloat'),
             ('post_comment', 'highfive.newpr.HighfiveHandler.post_comment'),
         ))
 
@@ -654,11 +669,13 @@ class TestPostWarnings(TestNewPR):
     def test_no_warnings(self):
         self.mocks['unexpected_branch'].return_value = False
         self.mocks['modifies_submodule'].return_value = False
+        self.mocks['modifies_apfloat'].return_value = False
 
         self.post_warnings()
 
         self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_apfloat'].assert_called_with(self.diff)
         self.mocks['post_comment'].assert_not_called()
 
     def test_unexpected_branch(self):
@@ -666,11 +683,13 @@ class TestPostWarnings(TestNewPR):
             'master', 'something-else'
         )
         self.mocks['modifies_submodule'].return_value = False
+        self.mocks['modifies_apfloat'].return_value = False
 
         self.post_warnings()
 
         self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_apfloat'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:
 
@@ -682,11 +701,13 @@ class TestPostWarnings(TestNewPR):
     def test_modifies_submodule(self):
         self.mocks['unexpected_branch'].return_value = False
         self.mocks['modifies_submodule'].return_value = True
+        self.mocks['modifies_apfloat'].return_value = False
 
         self.post_warnings()
 
         self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_apfloat'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:
 
@@ -700,16 +721,40 @@ class TestPostWarnings(TestNewPR):
             'master', 'something-else'
         )
         self.mocks['modifies_submodule'].return_value = True
+        self.mocks['modifies_apfloat'].return_value = False
 
         self.post_warnings()
 
         self.mocks['unexpected_branch'].assert_called_once_with()
         self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_apfloat'].assert_called_with(self.diff)
 
         expected_warning = """:warning: **Warning** :warning:
 
 * Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!
 * These commits modify **submodules**."""
+        self.mocks['post_comment'].assert_called_with(
+            expected_warning, self.owner, self.repo, self.issue
+        )
+
+    def test_unexpected_branch_modifies_submodule_and_apfloat(self):
+        self.mocks['unexpected_branch'].return_value = (
+            'master', 'something-else'
+        )
+        self.mocks['modifies_submodule'].return_value = True
+        self.mocks['modifies_apfloat'].return_value = True
+
+        self.post_warnings()
+
+        self.mocks['unexpected_branch'].assert_called_once_with()
+        self.mocks['modifies_submodule'].assert_called_with(self.diff)
+        self.mocks['modifies_apfloat'].assert_called_with(self.diff)
+
+        expected_warning = """:warning: **Warning** :warning:
+
+* Pull requests are usually filed against the master branch for this repo, but this one is against something-else. Please double check that you specified the right target!
+* These commits modify **submodules**.
+* These commits modify **software floating point**. (cc @eddyb)"""
         self.mocks['post_comment'].assert_called_with(
             expected_warning, self.owner, self.repo, self.issue
         )


### PR DESCRIPTION
@eddyb [wrote](https://github.com/rust-lang/rust/pull/83185#issuecomment-800275389):
> Can we add a rule somewhere that makes rust-highfive ping me whenever someone touches `compiler/rustc_apfloat`?

Your wish is my command! :genie_man: 

(This will also hopefully flush out any issues with my in-draft PR which takes a similar approach.)