### PR TITLE
Fix tests in Windows

### DIFF
--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -168,7 +168,7 @@ Please see [the contribution instructions](%s) for more information.
                 'builtins.open', mock.mock_open(read_data=json.dumps(contents))
         ) as mock_file:
             assert handler._load_json_file('a-config.json') == contents
-            mock_file.assert_called_with('/the/path/configs/a-config.json')
+            mock_file.assert_called_with(os.path.join(mock_dirname.return_value, 'configs', 'a-config.json'))
 
     @mock.patch('highfive.newpr.HighfiveHandler.api_req')
     def test_post_comment_success(self, mock_api_req):


### PR DESCRIPTION
Before, trying to run `pytest -m hermetic` raise the error:
```
self = <highfive.tests.test_newpr.TestNewPRGeneral object at 0x0000027179D0B460>, mock_dirname = <MagicMock name='dirname' id='2686398201184'>

    @mock.patch('os.path.dirname')
    def test_load_json_file(self, mock_dirname):
        handler = HighfiveHandlerMock(Payload({})).handler
        mock_dirname.return_value = '/the/path'
        contents = ['some json']
        with mock.patch(
                'builtins.open', mock.mock_open(read_data=json.dumps(contents))
        ) as mock_file:
            assert handler._load_json_file('a-config.json') == contents
>           mock_file.assert_called_with('/the/path/configs/a-config.json')

highfive\tests\test_newpr.py:171:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

_mock_self = <MagicMock name='open' spec='builtin_function_or_method' id='2686398134448'>, args = ('/the/path/configs/a-config.json',), kwargs = {}, expected = call('', ('/the/path/configs/a-config.json',), {})  
actual = call('', ('/the/path\\configs\\a-config.json',), {}), _error_message = <function NonCallableMock.assert_called_with.<locals>._error_message at 0x0000027178CA2940>, cause = None

    def assert_called_with(_mock_self, *args, **kwargs):
        """assert that the last call was made with the specified arguments.

        Raises an AssertionError if the args and keyword args passed in are
        different to the last call to the mock."""
            error_message = ('expected call not found.\nExpected: %s\nActual: %s'
                    % (expected, actual))
            raise AssertionError(error_message)

        def _error_message():
            msg = self._format_mock_failure_message(args, kwargs)
            return msg
        expected = self._call_matcher(_Call((args, kwargs), two=True))
        actual = self._call_matcher(self.call_args)
        if actual != expected:
            cause = expected if isinstance(expected, Exception) else None
>           raise AssertionError(_error_message()) from cause
E           AssertionError: expected call not found.
E           Expected: open('/the/path/configs/a-config.json')
E           Actual: open('/the/path\\configs\\a-config.json')

.env\lib\site-packages\mock\mock.py:913: AssertionError
```

Now it could work in Windows and Linux.