### PR TITLE
Fix the case of my username so highfive doesn't assign me my own PRs

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -13,7 +13,7 @@
         ],
         "libs": [
             "@dtolnay",
-            "@JoshTriplett",
+            "@joshtriplett",
             "@Mark-Simulacrum",
             "@kennytm",
             "@m-ou-se",


### PR DESCRIPTION
Per the discusion at https://github.com/rust-lang/highfive/issues/326 ,
this happened because highfive has me in the rotation as `JoshTriplett`,
but GitHub has my username as `joshtriplett`, and highfive checks for an
exact match including case.