### PR TITLE
remove lcnr from the review rotation

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -6,7 +6,6 @@
             "@matthewjasper",
             "@petrochenkov",
             "@varkor",
-            "@lcnr",
             "@davidtwco"
         ],
         "compiler-team-contributors": [


### PR DESCRIPTION
Taking a break so I won't be able to review any PRs until I return.