### PR TITLE
Don't ping file reviewers if they are the PR author (take 2)

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -352,7 +352,7 @@ class HighfiveHandler(object):
         mention_list = []
         for mention in to_mention:
             entry = mentions[mention]
-            if entry["reviewers"] != author:
+            if author not in entry["reviewers"]:
                 mention_list.append(entry)
         return mention_list
 


### PR DESCRIPTION
`reviewers` is a list, not a string.

cc https://github.com/rust-lang/highfive/pull/281#issuecomment-847328963