### PR TITLE
Fix rust-clippy.json

### DIFF
--- a/highfive/configs/rust-lang/rust-clippy.json
+++ b/highfive/configs/rust-lang/rust-clippy.json
@@ -3,7 +3,7 @@
         "all": ["@flip1995", "@Manishearth", "@llogiq", "@camsteffen", "@giraffate"]
     },
     "dirs": {
-        ".github": ["@flip1995"],
+        ".github": ["@flip1995"]
     },
     "contributing": "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md",
     "new_pr_labels": ["S-waiting-on-review"]


### PR DESCRIPTION
This broke the rust-highfive bot for Clippy.

Should we (I can do that) add a GHA to verify that the json files are valid before merging?