### PR TITLE
Fix the configs pytest

### DIFF
--- a/highfive/configs/rust-lang/rustc-guide.json
+++ b/highfive/configs/rust-lang/rustc-guide.json
@@ -3,5 +3,5 @@
       "all": ["@nikomatsakis", "@mark-i-m"]
     },
     "dirs": {
-    },
+    }
 }

--- a/highfive/tests/test_configs.py
+++ b/highfive/tests/test_configs.py
@@ -104,11 +104,11 @@ def config_valid(fname):
 
 @pytest.mark.config
 @pytest.mark.hermetic
-@pytest.fixture
 def test_configs(request):
     """Check that the repo config files are valid JSON and contain the expected
     sorts of values."""
     config_path = os.path.join(str(request.config.rootdir), 'highfive/configs')
-    for fname in os.listdir(config_path):
-        if fname.endswith('.json'):
-            assert config_valid(os.path.join(config_path, fname))
+    for root, _, files in os.walk(config_path):
+        for fname in files:
+            if fname.endswith('.json'):
+                assert config_valid(os.path.join(root, fname))


### PR DESCRIPTION
This test was marked as a fixture. This didn't make much sense to me.

Now this test is run as any other test and works, as seen with the
rustc-guide json file, where it detected that this file was broken.

r? @Mark-Simulacrum 

cc https://github.com/rust-lang/highfive/pull/343#issuecomment-876464166 

This was easier than expected, since the test already existed. For some reason it was marked as a fixture, but never used as a fixture in any other test. 

In addition this test only checked the `_global.json` file. Now it checks every `json` file in the `configs` dir. 

---

~~One~~ Two more questions: Should I rename `rustc-guide.json` to `rustc-dev-guide.json` while I'm at it or is there a reason why it is still named `rustc-guide.json`? Also the config file for this repo is still in the `rust-lang-nursery` dir and I think that is why the rust-highfive bot doesn't do anything on PRs towards this repo. Should I move that file?