### PR TITLE
also ping us on submodule changes

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -121,6 +121,10 @@
         "compiler/rustc_middle/src/mir/interpret": {
             "message": "Some changes occured to the CTFE / Miri engine",
             "reviewers": ["@rust-lang/miri"]
+        },
+        "src/tools/miri": {
+            "message": "Some changes occured to the Miri submodule",
+            "reviewers": ["@rust-lang/miri"]
         }
     },
     "new_pr_labels": ["S-waiting-on-review"]


### PR DESCRIPTION
I keep doing this by hand, but no reason we can't automate this -- assuming highfive handles submodules correctly.

Cc @rust-lang/miri