### PR TITLE
Add groups from expert map

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -16,6 +16,10 @@
             "@LeSeulArtichaut",
             "@cjgillot"
         ],
+        "compiler": [
+            "compiler-team",
+            "compiler-team-contributors"
+        ],
         "libs": [
             "@dtolnay",
             "@joshtriplett",
@@ -33,42 +37,95 @@
             "@GuillaumeGomez",
             "@ollie27",
             "@CraftSpider"
+        ],
+        "query-system": [
+            "@cjgillot"
+        ],
+        "incremental": [
+            "@michaelwoerister",
+            "@wesleywiser"
+        ],
+        "typeck": [],
+        "diagnostics": [
+            "@davidtwco",
+            "@estebank",
+            "@oli-obk"
+        ],
+        "parser": [
+            "@davidtwco",
+            "@estebank",
+            "@petrochenkov"
+        ],
+        "lexer": [
+            "@petrochenkov"
+        ],
+        "mir": [
+            "@davidtwco",
+            "@oli-obk"
+        ],
+        "mir-opt": [
+            "@nagisa",
+            "@oli-obk",
+            "@wesleywiser"
+        ],
+        "traits": [
+            "@jackh726",
+            "@matthewjasper"
+        ],
+        "borrowck": [
+            "@davidtwco",
+            "@matthewjasper",
+            "@pnkfelix"
         ]
     },
     "dirs": {
-        ".github/workflows":        ["infra-ci"],
-        "Cargo.lock":               ["@Mark-Simulacrum"],
-        "Cargo.toml":               ["@Mark-Simulacrum"],
-        "compiler":                 ["compiler-team", "compiler-team-contributors"],
-        "compiler/rustc_apfloat":   ["@eddyb"],
-        "compiler/rustc_llvm":      ["@cuviper"],
-        "library/alloc":            ["libs"],
-        "library/core":             ["libs", "@scottmcm"],
-        "library/panic_abort":      ["libs"],
-        "library/panic_unwind":     ["libs"],
-        "library/proc_macro":       ["@petrochenkov"],
-        "library/std":              ["libs"],
-        "library/stdarch":          ["libs"],
-        "library/term":             ["libs"],
-        "library/test":             ["libs"],
-        "src/bootstrap":            ["@Mark-Simulacrum"],
-        "src/build_helper":         ["@Mark-Simulacrum"],
-        "src/ci":                   ["infra-ci"],
-        "src/doc":                  ["doc"],
-        "src/etc":                  ["@Mark-Simulacrum"],
-        "src/librustdoc":           ["rustdoc"],
-        "src/llvm-project":         ["@cuviper"],
-        "src/stage0.txt":           ["@Mark-Simulacrum"],
-        "src/tools/cargo":          ["@ehuss", "@joshtriplett"],
-        "src/tools/compiletest":    ["@Mark-Simulacrum", "@Centril"],
-        "src/tools/linkchecker":    ["@ehuss"],
-        "src/tools/rust-installer": ["@Mark-Simulacrum"],
-        "src/tools/rustbook":       ["doc", "@ehuss"],
-        "src/tools/rustdoc":        ["rustdoc"],
-        "src/tools/rustdoc-js":     ["rustdoc"],
-        "src/tools/rustdoc-js-std": ["rustdoc"],
-        "src/tools/rustdoc-themes": ["rustdoc"],
-        "src/tools/tidy":           ["@Mark-Simulacrum"]
+        ".github/workflows":                     ["infra-ci"],
+        "Cargo.lock":                            ["@Mark-Simulacrum"],
+        "Cargo.toml":                            ["@Mark-Simulacrum"],
+        "compiler":                              ["compiler"],
+        "compiler/rustc_apfloat":                ["@eddyb"],
+        "compiler/rustc_ast/":                   ["compiler", "parser"],
+        "compiler/rustc_lexer":                  ["compiler", "lexer"],
+        "compiler/rustc_llvm":                   ["@cuviper"],
+        "compiler/rustc_middle/src/mir":         ["compiler", "mir"],
+        "compiler/rustc_middle/src/traits":      ["compiler", "traits"],
+        "compiler/rustc_mir/src/interpret":      ["compiler", "mir"],
+        "compiler/rustc_mir/src/transform":      ["compiler", "mir-opt"],
+        "compiler/rustc_mir_build/src/build":    ["compiler", "mir"],
+        "compiler/rustc_typeck":                 ["compiler", "typeck"],
+        "compiler/rustc_traits":                 ["compiler", "traits"],
+        "compiler/rustc_trait_selection":        ["compiler", "traits"],
+        "compiler/rustc_parse":                  ["compiler", "parser"],
+        "compiler/rustc_parse/src/parse/lexer/": ["compiler", "lexer"],
+        "compiler/rustc_query_impl":             ["compiler", "query-system"],
+        "compiler/rustc_query_system":           ["compiler", "query-system"],
+        "library/alloc":                         ["libs"],
+        "library/core":                          ["libs", "@scottmcm"],
+        "library/panic_abort":                   ["libs"],
+        "library/panic_unwind":                  ["libs"],
+        "library/proc_macro":                    ["@petrochenkov"],
+        "library/std":                           ["libs"],
+        "library/stdarch":                       ["libs"],
+        "library/term":                          ["libs"],
+        "library/test":                          ["libs"],
+        "src/bootstrap":                         ["@Mark-Simulacrum"],
+        "src/build_helper":                      ["@Mark-Simulacrum"],
+        "src/ci":                                ["infra-ci"],
+        "src/doc":                               ["doc"],
+        "src/etc":                               ["@Mark-Simulacrum"],
+        "src/librustdoc":                        ["rustdoc"],
+        "src/llvm-project":                      ["@cuviper"],
+        "src/stage0.txt":                        ["@Mark-Simulacrum"],
+        "src/tools/cargo":                       ["@ehuss", "@joshtriplett"],
+        "src/tools/compiletest":                 ["@Mark-Simulacrum"],
+        "src/tools/linkchecker":                 ["@ehuss"],
+        "src/tools/rust-installer":              ["@Mark-Simulacrum"],
+        "src/tools/rustbook":                    ["doc", "@ehuss"],
+        "src/tools/rustdoc":                     ["rustdoc"],
+        "src/tools/rustdoc-js":                  ["rustdoc"],
+        "src/tools/rustdoc-js-std":              ["rustdoc"],
+        "src/tools/rustdoc-themes":              ["rustdoc"],
+        "src/tools/tidy":                        ["@Mark-Simulacrum"]
     },
     "mentions": {
         "src/rustdoc-json-types": {

--- a/highfive/tests/fakes.py
+++ b/highfive/tests/fakes.py
@@ -44,6 +44,15 @@ def get_repo_configs():
                 "some": ["all"],
             },
         },
+        'nested_groups': {
+            "groups": {
+                "all": [],
+                "a": ["@pnkfelix"],
+                "b": ["@nrc"],
+                "c": ["a", "b"]
+            },
+            "dirs": {"src/librustc_typeck": ["c"]},
+        },
         'empty': {
             "groups": {"all": []},
             "dirs": {},

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -1160,6 +1160,17 @@ class TestChooseReviewer(TestNewPR):
                 'rust', 'rust-lang', self.fakes['diff']['normal'], 'fooauthor'
             )
 
+    def test_nested_groups(self):
+        """Test choosing a reviewer from group with nested groups.
+        """
+        self.handler = HighfiveHandlerMock(
+            Payload({}), repo_config=self.fakes['config']['nested_groups']
+        ).handler
+        (chosen_reviewers, mentions) = self.choose_reviewers(
+            self.fakes['diff']['normal'], "nikomatsakis"
+        )
+        assert set(["pnkfelix", "nrc"]) == chosen_reviewers
+
     def test_global_core(self):
         """Test choosing a reviewer from the core group in the global
         configuration.


### PR DESCRIPTION
First, I added a new "compiler" group which nests the "compiler-team" and "compiler-team-contributors". Highfive should just expand this into the union of the two groups (I added a test just make sure we don't lose this behavior).

I also added several teams from the expert map, particularly those which seemed "common" enough that they could use more specific reviewers. When applicable, I added the team to directories found in the expert map. For these new directories, I added both the "compiler" group as well as the team to the directory. I'm not 100% sure highfive is smart enough to distinguish between `compiler/rustc_mir/src/interpret` and `compiler/rustc_mir/src/transform`, but this could be in a separate PR if not. Also, doing it this way (with the current reviewer choosing code), seems like it *slightly* favors selecting people in both groups (it uses a list instead of a set). This is probably fine (maybe desired?), but this could be changed separately too.

I didn't add people who were in the expert map but not in the current reviewers groups.

Some comments on groups:
- I didn't include the "miri" group, but did include the directories under the "mir" group
- "MIR structure/construction" -> "mir"
- AST-borrow checker & MIR borrow check -> "borrowck"
- The following groups I didn't add (and reasons)
  - RLS - No directories, not needed
  - metadata encoding/decoding - doesn't come up often, might make sense in a more general group
  - codegen unit partitioning - should probably be part of a "codegen" group
  - ThinLTO - Maybe should be in a "codegen" group?
  - linker-plugin LTO (xLTO) - Maybe should be in a "codegen" group?
  - Grammar - No directories, should maybe just be in parser/lexer
  - Type layout - Maybe in a "codegen" group?
  - match/exhaustiveness - Doesn't come up often
  - Polonius - Maybe just part of "borrowck"
  - AST -> HIR lowering - Probably relevant, but might make more sense as a more general "ast-hir" group
  - debuginfo - Probably should be a group
  - drop-check - Doesn't come up often
  - dataflow - Doesn't come up often
  - drop elaboration - Doesn't come up often
  - Privacy - Doesn't come up often, might make sense in an "ast-hir" group
  - Name resolution, hygiene - Seems pretty specific, can we generalize?
  - Macro expansion - Maybe a "macros" group?
  - `macro_rules` parsing and checking - Maybe a "macros" group?
  - Generators - Seems very specific, who "owns" this?
  - Self profiler - Doesn't come up often