### PR TITLE
crates.io: Add Turbo87 to `all` group

### DIFF
--- a/highfive/configs/rust-lang/crates.io.json
+++ b/highfive/configs/rust-lang/crates.io.json
@@ -1,7 +1,7 @@
 {
     "groups": {
-        "all": ["@jtgeibel", "@carols10cents", "@smarnach"],
-        "ember": ["@locks", "@Turbo87"]
+        "all": ["@jtgeibel", "@carols10cents", "@smarnach", "@Turbo87"],
+        "ember": ["@locks"]
     },
     "dirs": {
         "package.json": ["ember"],


### PR DESCRIPTION
I've been doing reviews on the backend part of the codebase for a while now, so I guess there is no reason anymore to not be automatically assigned to those kinds of PRs too.

/cc @pietroalbini @jtgeibel