### PR TITLE
Remove ollie from the rustdoc review queue

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -1,4 +1,4 @@
-l{
+{
     "groups": {
         "all": [],
         "compiler-team": [

--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -1,4 +1,4 @@
-{
+l{
     "groups": {
         "all": [],
         "compiler-team": [
@@ -35,7 +35,6 @@
         ],
         "rustdoc": [
             "@GuillaumeGomez",
-            "@ollie27",
             "@CraftSpider"
         ],
         "query-system": [


### PR DESCRIPTION
They haven't been actively reviewing in 6+ months; in the past I was reassigning their PRs to mine, but I don't want to keep doing that. They're still a member of the team and can raise blocking concerns on RFCs/FCPs if they wish.

cc @rust-lang/rustdoc esp. @ollie27 - this leaves only two people on the review queue, so it would be great if a few of you could join the rotation.