### PR TITLE
Add notriddle to rustdoc rotation

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -36,7 +36,8 @@
         "rustdoc": [
             "@jsha",
             "@GuillaumeGomez",
-            "@CraftSpider"
+            "@CraftSpider",
+            "@notriddle"
         ],
         "query-system": [
             "@cjgillot"


### PR DESCRIPTION
@notriddle nicely accepted to be part of the rustdoc reviews rotation. Not sure if https://github.com/rust-lang/team/pull/693 needs to be merged first though?