### PR TITLE
Adjust reviewer selection to work on unprefixed group selection

### DIFF
--- a/highfive/tests/fakes.py
+++ b/highfive/tests/fakes.py
@@ -86,7 +86,7 @@ def get_repo_configs():
             }
         },
         'teams': {
-            "groups": {"all": [], "a": ["@pnkfelix"], "b/c": ["@nrc"]}
+            "groups": {"all": [], "a": ["@pnkfelix"], "d": ["@e"], "compiler-team": ["@niko"], "b/c": ["@nrc"]}
         }
     }
 

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -348,7 +348,8 @@ Please see [the contribution instructions](%s) for more information.
             # https://github.com/rust-lang-nursery/highfive/issues/184
             None,
         )
-        handler = HighfiveHandlerMock(Payload({})).handler
+        config = {}
+        handler = HighfiveHandlerMock(Payload({}), repo_config=config).handler
 
         for (msg, reviewer) in found_cases:
             assert handler.find_reviewer(msg, None) == reviewer, \
@@ -1280,8 +1281,15 @@ class TestChooseReviewer(TestNewPR):
         found_cases = (
             ("r? @foo/a", "pnkfelix"),
             ("r? foo/a", "pnkfelix"),
+            ("r? rust-lang/compiler-team", "niko"),
+            ("r? compiler-team", "niko"),
             ("r? @b/c", "nrc"),
             ("r? b/c", "nrc"),
+
+            # @d goes to the user
+            ("r? @d", "d"),
+            # d goes to the team
+            ("r? d", "e"),
         )
 
         not_found_cases = (


### PR DESCRIPTION
Previously, `r? compiler-team` or `r? pnkfelix` would not be matched by the regexes, which meant that they'd be silently ignored. `r? rust-lang/compiler-team` already worked, though. Note that if a user and team name overlap, then `r? @foo` will always map to foo the user, while `r? foo` will map to the team.

Since we generally don't want the `@` prefix on team-wide pings, since it subscribes a bunch of people for no reason, it's nice to avoid necessarily typing the prefix as well. Users in practice do invoke the command in that way.