### PR TITLE
Remove implicit "all" group choice.

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -252,8 +252,6 @@ class HighfiveHandler(object):
             if match:
                 groups = self.get_groups()
                 potential = groups.get(match.group(2)) or groups.get("%s/%s" % (match.group(1), match.group(2))) or []
-                if 'all' in groups:
-                    potential.extend(groups["all"])
                 picked = self.pick_reviewer(groups, potential, exclude)
                 if picked:
                     return picked

--- a/highfive/tests/fakes.py
+++ b/highfive/tests/fakes.py
@@ -86,7 +86,7 @@ def get_repo_configs():
             }
         },
         'teams': {
-            "groups": {"all": [], "a": ["@pnkfelix"], "d": ["@e"], "compiler-team": ["@niko"], "b/c": ["@nrc"]}
+            "groups": {"all": ["@ehuss"], "a": ["@pnkfelix"], "d": ["@e"], "compiler-team": ["@niko"], "b/c": ["@nrc"]}
         }
     }
 


### PR DESCRIPTION
This removes the implicit choice of the "all" group in the explicit reviewer pick.  This prevented repositories that have an "all" group from being able to `r? someuser`, since it would always just pick from "all".

This was regressed in #377, but instead of trying to bring back the previous behavior (where "all" was only included when a group was matched), this just removes "all" altogether.  There was a comment at https://github.com/rust-lang/highfive/pull/249#discussion_r666504539 about this, but the explanation didn't make sense to me.  If you say `r? somegroup`, I think it should only pick from that group and not include "all".

Fixes #380