### PR TITLE
Improve rustdoc-json-types message

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -130,7 +130,7 @@
     },
     "mentions": {
         "src/rustdoc-json-types": {
-          "message": "rustdoc-json-types is a **public** (although nightly-only) API. Consider changing `src/librustdoc/json/conversions.rs` instead; otherwise, make sure you update `format_version`.",
+          "message": "rustdoc-json-types is a **public** (although nightly-only) API. If possible, consider changing `src/librustdoc/json/conversions.rs`; otherwise, make sure you bump the `FORMAT_VERSION` constant.",
           "reviewers": ["@CraftSpider", "@aDotInTheVoid"]
         },
         "src/librustdoc/clean/types.rs": {


### PR DESCRIPTION
Most of the PR's right now do need to change the types, so be clearer about that.

Additionally, be clearer about what `FORMAT_VERSION` is, and how it needs to be changed.