### PR TITLE
Remove myself from reviewer rotations

### DIFF
--- a/highfive/configs/_global.json
+++ b/highfive/configs/_global.json
@@ -1,7 +1,7 @@
 {
     "groups": {
         "core": ["@Mark-Simulacrum"],
-        "crates": ["@alexcrichton"],
+        "crates": [],
         "doc": ["@steveklabnik", "@GuillaumeGomez"],
         "rust-embedded/cortex-a": ["@andre-richter", "@raw-bin"],
         "rust-embedded/cortex-m": ["@adamgreig", "@therealprof", "@jonas-schievink", "@thalesfragoso"],

--- a/highfive/configs/rust-lang/cargo.json
+++ b/highfive/configs/rust-lang/cargo.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["@alexcrichton", "@ehuss"]
+        "all": ["@ehuss"]
     },
     "contributing": "https://github.com/rust-lang/cargo/blob/master/CONTRIBUTING.md",
     "new_pr_labels": ["S-waiting-on-review"]

--- a/highfive/configs/rust-lang/rust-installer.json
+++ b/highfive/configs/rust-lang/rust-installer.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["@alexcrichton"]
+        "all": []
     },
     "dirs": {
     }


### PR DESCRIPTION
I'm stepping down from the Cargo team, so I won't be in the rotation for
reviewers there any more. I additionally went ahead and cleaned up
myself from other configs as well.