### PR TITLE
add config for std-dev-guide repo

### DIFF
--- a/highfive/configs/rust-lang/std-dev-guide.json
+++ b/highfive/configs/rust-lang/std-dev-guide.json
@@ -1,11 +1,10 @@
 {
     "groups": {
         "all": [
-            "@dtolnay",
             "@joshtriplett",
-            "@Mark-Simulacrum",
-            "@kennytm",
             "@yaahc",
+            "cuviper",
+            "Amanieu",
             "@m-ou-se"
         ]
     },

--- a/highfive/configs/rust-lang/std-dev-guide.json
+++ b/highfive/configs/rust-lang/std-dev-guide.json
@@ -1,0 +1,14 @@
+{
+    "groups": {
+        "all": [
+            "@dtolnay",
+            "@joshtriplett",
+            "@Mark-Simulacrum",
+            "@kennytm",
+            "@yaahc",
+            "@m-ou-se"
+        ]
+    },
+    "contributing": "https://github.com/rust-lang/cargo/blob/master/CONTRIBUTING.md",
+    "new_pr_labels": ["S-waiting-on-review"]
+}

--- a/highfive/configs/rust-lang/std-dev-guide.json
+++ b/highfive/configs/rust-lang/std-dev-guide.json
@@ -9,6 +9,5 @@
             "@m-ou-se"
         ]
     },
-    "contributing": "https://github.com/rust-lang/cargo/blob/master/CONTRIBUTING.md",
     "new_pr_labels": ["S-waiting-on-review"]
 }


### PR DESCRIPTION
This just copies the existing reviewer set from the libs review rotation, I figured ppl can remove themselves afterwards rather than trying to get everyone to confirm they want or don't want to get added.