### PR TITLE
Notify veykril about changes in `library/proc_macro`

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -188,6 +188,10 @@
         "src/tools/miri": {
             "message": "Some changes occured to the Miri submodule",
             "reviewers": ["@rust-lang/miri"]
+        },
+        "library/proc_macro": {
+            "message": "Some changes occurred in src/library/proc_macro.",
+            "reviewers": ["@Veykril"]
         }
     },
     "new_pr_labels": ["S-waiting-on-review"]


### PR DESCRIPTION
`rust-analyzer` requires changes to its proc-macro abi implementations whenever it changes and usually we notice it changing only when the first issues appear in the r-a repo.
Having at least one of us be pinged about changes to it would be rather helpful in that case.