### PR TITLE
split libs review rotation in two

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -23,13 +23,18 @@
             "compiler-team-contributors"
         ],
         "libs": [
-            "@dtolnay",
             "@joshtriplett",
             "@Mark-Simulacrum",
             "@kennytm",
             "@yaahc",
             "@m-ou-se",
             "@thomcc"
+        ],
+        "libs-api": [
+            "@dtolnay",
+            "@joshtriplett",
+            "@yaahc",
+            "@m-ou-se"
         ],
         "infra-ci": [
             "@Mark-Simulacrum",
@@ -192,6 +197,10 @@
         "src/tools/miri": {
             "message": "Some changes occured to the Miri submodule",
             "reviewers": ["@rust-lang/miri"]
+        },
+        "library": {
+            "message": "Thank you for submitting a new PR for the library teams! If this PR contains a stabilization of a library feature that has not already completed FCP in its tracking issue, introduces new or changes existing unstable library APIs, or changes our public documentation in ways that create new stability guarantees then please comment with `r? rust-lang/libs-api @rustbot label +T-libs-api` to request review from a libs-api team reviewer. If you're unsure where your change falls no worries, just leave it as is and the reviewer will take a look and make a decision to forward on if necessary",
+            "reviewers": []
         }
     },
     "new_pr_labels": ["S-waiting-on-review"]

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -129,11 +129,19 @@ class HighfiveHandler(object):
                 if len(message) > 0:
                     message += '\n\n'
                 msg = mention.get('message')
+                reviewers = [x for x in mention['reviewers'] if x != user]
+
                 if msg is not None:
-                    msg += '\n\n'
+                    if len(reviewers) > 0:
+                        msg += '\n\n'
                 else:
                     msg = ''
-                message += "%scc %s" % (msg, ','.join([x for x in mention['reviewers'] if x != user]))
+
+                if len(reviewers) > 0:
+                    message += "%scc %s" % (msg, ','.join(reviewers))
+                else:
+                    message += msg
+
                 cmd = mention.get('command')
                 if cmd is not None:
                     commands[cmd] = self.payload['pull_request', 'head', 'sha']

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -564,12 +564,16 @@ class TestSetAssignee(TestNewPR):
                 'message': 'Also important',
                 'reviewers': ['@userD'],
             },
+            {
+                'message': 'last message but this one has nobody to mention associated with it',
+                'reviewers': [],
+            },
         ]
         self.set_assignee(to_mention=to_mention)
 
         self.assert_api_req_call()
         self.mocks['post_comment'].assert_called_once_with(
-            'This is important\n\ncc @userA,@userB,@userC\n\nAlso important\n\ncc @userD',
+            'This is important\n\ncc @userA,@userB,@userC\n\nAlso important\n\ncc @userD\n\nlast message but this one has nobody to mention associated with it',
             self.owner, self.repo, self.issue
         )
 


### PR DESCRIPTION
The libs team discussed how we could improve review bandwidth for libs vs libs-api PRs and came to the conclusion that the best first step would be to separate the review rotations.

The goal of this split is to allow team members to focus on subsets of library work that they're most interested in and to allow independent growth of the review rotation focused on non-API affecting changes (aka libs PRs vs libs-api PRs). The libs APIs are generally less common, easier to review, often more time sensitive, and a much better entry point for new contributors interested in participating in the libs team. These properties make this an ideal starting point for new libs reviewers and contributors. By splitting the review rotations and focusing on increasing review bandwidth for non-API changes we can make this contribution experience more pleasant which will encourage repeat contributors and increase how much important bug fix / perf improvement / doc improvement style work we get done as a team.