### PR TITLE
Add me for Windows std highfives

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -108,6 +108,7 @@
         "library/panic_unwind":                  ["libs"],
         "library/proc_macro":                    ["@petrochenkov"],
         "library/std":                           ["libs"],
+        "library/std/src/sys/windows":           ["@ChrisDenton"],
         "library/stdarch":                       ["libs"],
         "library/term":                          ["libs"],
         "library/test":                          ["libs"],


### PR DESCRIPTION
Specifically for the `library/std/src/sys/windows` directory.

Hopefully I've done this right. :)