### PR TITLE
use team for rustfmt change notifications

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -180,7 +180,7 @@
         },
         "src/tools/rustfmt": {
             "message": "Some changes occurred in src/tools/rustfmt.",
-            "reviewers": ["@calebcartwright"]
+            "reviewers": ["@rust-lang/rustfmt"]
         },
         "src/tools/clippy": {
             "message": "Some changes occurred in src/tools/clippy.",


### PR DESCRIPTION
Now that I'm no longer the sole active rustfmt member and the team membership is accurate, it makes sense to use the team reference instead 