### PR TITLE
Improve library team mention message for consistency

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -199,7 +199,7 @@
             "reviewers": ["@rust-lang/miri"]
         },
         "library": {
-            "message": "Thank you for submitting a new PR for the library teams! If this PR contains a stabilization of a library feature that has not already completed FCP in its tracking issue, introduces new or changes existing unstable library APIs, or changes our public documentation in ways that create new stability guarantees then please comment with `r? rust-lang/libs-api @rustbot label +T-libs-api` to request review from a libs-api team reviewer. If you're unsure where your change falls no worries, just leave it as is and the reviewer will take a look and make a decision to forward on if necessary",
+            "message": "Hey! It looks like you've submitted a new PR for the library teams!\n\nIf this PR contains changes to any `rust-lang/rust` public library APIs then please comment with `r? rust-lang/libs-api @rustbot label +T-libs-api` to request review from a libs-api team reviewer. If you're unsure where your change falls no worries, just leave it as is and the reviewer will take a look and make a decision to forward on if necessary.\n\nExamples of `T-libs-api` changes:\n\n* a stabilization of a library feature\n* introducing new or changes existing unstable library APIs\n* changes to  public documentation in ways that create new stability guarantees",
             "reviewers": []
         }
     },


### PR DESCRIPTION
Further continuations upon https://github.com/rust-lang/rust/pull/95986.

I reviewed the output after the previous change to add the to_mention message for libs and wasn't thrilled with the output. It seemed to duplicate the welcome message that highfive posts generally as well as being very information dense. I've tried to reorder how we present information and reframe it so it flows well with the subsequent welcome message.

I tried reordering it all together so the welcome message comes first, but it appears that the `self.set_assignee` function needs to be called first before `self.is_new_contributor` or else some of the state within the Handler ends up being a python dict instead of the expected JSON... Didn't feel like debugging or refactoring that, but I think I've arrived upon a wording that looks good even if it comes first. Also this way I don't necessarily mess up other team's welcome messages that may already be optimal if placed first.