### PR TITLE
Remove fee1-dead from list of reviewers

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -14,8 +14,7 @@
         "compiler-team-contributors": [
             "@jackh726",
             "@cjgillot",
-            "@compiler-errors",
-            "@fee1-dead"
+            "@compiler-errors"
         ],
         "compiler": [
             "compiler-team",


### PR DESCRIPTION
I am currently in a tough personal situation, and I think it is best to reduce my involvement with the project at this time so I can resolve the situation. Sorry for leaving just a few weeks after I joined as a reviewer :( I would definitely rejoin after it has been resolved.