### PR TITLE
Remove yaahc from libs teams review rotations

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -24,14 +24,12 @@
             "@joshtriplett",
             "@Mark-Simulacrum",
             "@kennytm",
-            "@yaahc",
             "@m-ou-se",
             "@thomcc"
         ],
         "libs-api": [
             "@dtolnay",
             "@joshtriplett",
-            "@yaahc",
             "@m-ou-se"
         ],
         "infra-ci": [


### PR DESCRIPTION
Feeling exhausted by reviews recently so taking a break rather than burning myself out on it, hoping to be able to come back to this later, for now I'm still interested in reviewing anything related to things I've worked on, particularly error handling PRs, so feel free to reassign PRs to me if you feel I'd be interested in them.