### PR TITLE
Remove `self` from Clippy reviewer rotation

### DIFF
--- a/highfive/configs/rust-lang/rust-clippy.json
+++ b/highfive/configs/rust-lang/rust-clippy.json
@@ -1,6 +1,6 @@
 {
     "groups": {
-        "all": ["@flip1995", "@Manishearth", "@llogiq", "@camsteffen", "@giraffate", "@xFrednet"]
+        "all": ["@flip1995", "@Manishearth", "@llogiq", "@giraffate", "@xFrednet"]
     },
     "dirs": {
         ".github": ["@flip1995"]


### PR DESCRIPTION
I just haven't been active lately so I'd like to leave the rotation for now.