### PR TITLE
Set up rust-lang/types highfive alias

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -2,6 +2,7 @@
     "groups": {
         "all": [],
         "compiler-team": [
+            "@cjgillot",
             "@estebank",
             "@petrochenkov",
             "@davidtwco",
@@ -12,9 +13,8 @@
             "@wesleywiser"
         ],
         "compiler-team-contributors": [
-            "@jackh726",
-            "@cjgillot",
-            "@compiler-errors"
+            "@compiler-errors",
+            "@jackh726"
         ],
         "compiler": [
             "compiler-team",
@@ -45,8 +45,8 @@
             "@michaelwoerister",
             "@wesleywiser"
         ],
-        "typeck": [],
         "diagnostics": [
+            "@compiler-errors",
             "@davidtwco",
             "@estebank",
             "@oli-obk"
@@ -68,8 +68,11 @@
             "@oli-obk",
             "@wesleywiser"
         ],
-        "traits": [
-            "@jackh726"
+        "types": [
+            "@compiler-errors",
+            "@jackh726",
+            "@lcnr",
+            "@oli-obk"
         ],
         "borrowck": [
             "@davidtwco",
@@ -86,13 +89,14 @@
         "compiler/rustc_lexer":                  ["compiler", "lexer"],
         "compiler/rustc_llvm":                   ["@cuviper"],
         "compiler/rustc_middle/src/mir":         ["compiler", "mir"],
-        "compiler/rustc_middle/src/traits":      ["compiler", "traits"],
+        "compiler/rustc_middle/src/traits":      ["compiler", "types"],
         "compiler/rustc_mir/src/interpret":      ["compiler", "mir"],
         "compiler/rustc_mir/src/transform":      ["compiler", "mir-opt"],
         "compiler/rustc_mir_build/src/build":    ["compiler", "mir"],
-        "compiler/rustc_typeck":                 ["compiler", "typeck"],
-        "compiler/rustc_traits":                 ["compiler", "traits"],
-        "compiler/rustc_trait_selection":        ["compiler", "traits"],
+        "compiler/rustc_typeck":                 ["compiler", "types"],
+        "compiler/rustc_traits":                 ["compiler", "types"],
+        "compiler/rustc_trait_selection":        ["compiler", "types"],
+        "compiler/rustc_type_ir":                ["compiler", "types"],
         "compiler/rustc_parse":                  ["compiler", "parser"],
         "compiler/rustc_parse/src/parse/lexer/": ["compiler", "lexer"],
         "compiler/rustc_query_impl":             ["compiler", "query-system"],


### PR DESCRIPTION
inspired by https://github.com/rust-lang/rust/pull/97705#issuecomment-1148455153
> (do we have an alias for the types team?)

cc @rust-lang/types -- I only added the members of t-types who are already on the reviewer rotation, specifically excluding @nikomatsakis and @spastorino since they aren't currently on the rotation.

also add myself to diagnostics since i am a member of that wg, and move @cjgillot to the compiler team from the compiler team contributors grouping.