### PR TITLE
Re-add docs for rust-lang/rust

### DIFF
--- a/highfive/configs/_global.json
+++ b/highfive/configs/_global.json
@@ -2,7 +2,6 @@
     "groups": {
         "core": ["@Mark-Simulacrum"],
         "crates": [],
-        "doc": ["@steveklabnik", "@GuillaumeGomez"],
         "rust-embedded/cortex-a": ["@andre-richter", "@raw-bin"],
         "rust-embedded/cortex-m": ["@adamgreig", "@therealprof", "@jonas-schievink", "@thalesfragoso"],
         "rust-embedded/cortex-r": ["@japaric"],

--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -44,7 +44,8 @@
         ],
         "docs": [
             "@ehuss",
-            "@GuillaumeGomez"
+            "@GuillaumeGomez",
+            "@JohnTitor"
         ],
         "query-system": [
             "@cjgillot"

--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -42,6 +42,10 @@
             "@CraftSpider",
             "@notriddle"
         ],
+        "docs": [
+            "@ehuss",
+            "@GuillaumeGomez"
+        ],
         "query-system": [
             "@cjgillot"
         ],
@@ -130,7 +134,9 @@
         "src/tools/rustdoc-js":                  ["rustdoc"],
         "src/tools/rustdoc-js-std":              ["rustdoc"],
         "src/tools/rustdoc-themes":              ["rustdoc"],
-        "src/tools/tidy":                        ["bootstrap"]
+        "src/tools/tidy":                        ["bootstrap"],
+        "src/doc":                               ["docs"],
+        "src/doc/rustdoc":                       ["rustdoc"]
     },
     "mentions": {
         "src/rustdoc-json-types": {


### PR DESCRIPTION
Docs were removed in #408, but I think it is worthwhile to not assign everything to Mark.

This is somewhat blocked on #409 to work correctly.