### PR TITLE
Remove @kennytm from libs reviewers

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -24,7 +24,6 @@
         "libs": [
             "@joshtriplett",
             "@Mark-Simulacrum",
-            "@kennytm",
             "@m-ou-se",
             "@thomcc"
         ],


### PR DESCRIPTION
*(I hope this isn't out of line at all -- while I don't really know them personally, I respect @kennytm a great deal, and have for a while now)*

As noted in https://github.com/rust-lang/highfive/pull/416#issuecomment-1207734910 @kennytm is pretty inactive. To quantify this, https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Amerged+commenter%3Akennytm+%22approved+by+kennytm%22 says they've merged 3 reviews in the past year (EDIT: I think?). This is definitely an imperfect way to measure, but it seems infrequent enough that I think it's clear they're busy and the bot shouldn't auto-assign reviews to them.

(My motivation here is just that it ends up being a really bad contributor experience if they make a PR which gets assigned to an inactive reviewer -- this is most of why I go through [the list of PR's assigned to them](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+assignee%3Akennytm+label%3AS-waiting-on-review++label%3At-libs) periodically)

@kennytm: Sorry if I've misinterpreted your availability! And to be clear, I think we'd be happy to re-add you to the review rotation if you'd like in the future. (And you can still r+ stuff, this PR just covers whether or not you're auto-assigned by the highfive bot)

CC @m-ou-se who probably should make the final call on this stuff, as the libs lead.