### PR TITLE
Avoid an assertion error on double-adding a group

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -340,10 +340,10 @@ class HighfiveHandler(object):
                     reviewers.append(username)
             elif p in groups:
                 # avoid infinite loops
-                assert p not in seen, "group %s refers to itself" % p
-                seen.add(p)
-                # we allow groups in groups, so they need to be queued to be resolved
-                potential.extend(groups[p])
+                if p not in seen:
+                    seen.add(p)
+                    # we allow groups in groups, so they need to be queued to be resolved
+                    potential.extend(groups[p])
 
         if reviewers:
             random.seed()

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -1160,10 +1160,10 @@ class TestChooseReviewer(TestNewPR):
         handler = HighfiveHandlerMock(
             Payload({}), repo_config=self.fakes['config']['circular_groups']
         ).handler
-        with pytest.raises(AssertionError):
-            handler.choose_reviewer(
-                'rust', 'rust-lang', self.fakes['diff']['normal'], 'fooauthor'
-            )
+        chosen_reviewers = handler.choose_reviewer(
+            'rust', 'rust-lang', self.fakes['diff']['normal'], 'fooauthor'
+        )
+        assert chosen_reviewers is None
 
     def test_nested_groups(self):
         """Test choosing a reviewer from group with nested groups.


### PR DESCRIPTION
max_paths can contain the same group under multiple paths, I think,
though I didn't follow the code super closely. In any case, it seems
fine to just skip a double-added group rather than asserting it can't
happen.