### PR TITLE
Add `thomcc` as a reviewer for `std::sys::windows`

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -122,7 +122,7 @@
         "library/panic_unwind":                  ["libs"],
         "library/proc_macro":                    ["@petrochenkov"],
         "library/std":                           ["libs"],
-        "library/std/src/sys/windows":           ["@ChrisDenton"],
+        "library/std/src/sys/windows":           ["@ChrisDenton", "@thomcc"],
         "library/stdarch":                       ["libs"],
         "library/term":                          ["libs"],
         "library/test":                          ["libs"],


### PR DESCRIPTION
I have been reviewing patches in it for @ChrisDenton in this module for a while, and have plenty of background with windows programming from earlier in my career (although until recently it was pretty rusty). I also recently went through this module looking for issues (hence the PRs fixing alignment/uninit/zeroing/widening) and feel comfortable reviewing changes to it.

This also avoids cases like https://github.com/rust-lang/rust/pull/101481#issuecomment-1238048795 in the future, as now it has two reviewers (although it seems a little bit like a bug that it doesn't fall back to the rule for library/std in that case).