### PR TITLE
Mention @obi1kenobi for rustdoc JSON types changes

### DIFF
--- a/highfive/configs/rust-lang/rust.json
+++ b/highfive/configs/rust-lang/rust.json
@@ -145,5 +145,11 @@
         "src/doc":                               ["docs"],
         "src/doc/rustdoc":                       ["rustdoc"]
     },
+    "mentions": {
+        "src/rustdoc-json-types": {
+            "message": "Some changes occurred in the rustdoc JSON types module",
+            "reviewers": ["@obi1kenobi"]
+        }
+    },
     "new_pr_labels": ["S-waiting-on-review"]
 }


### PR DESCRIPTION
I'm one of the maintainers of `cargo-semver-checks`, and as mentioned [in Zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Long.20Term.20Rustdoc.20JSON.20Stability) it's very useful to me to know about upcoming rustdoc JSON types changes so I can be ready to publish new `cargo-semver-checks` releases compatible with the new JSON format.

I hope this is a reasonable and appropriate mechanism for that, and not an imposition on the team. If there's a better alternative I should try instead, I'd love to learn about it! Apologies for any mistakes in the file — this is the first time I've seen the internals of highfive.