### PR TITLE
Migrate rust-lang/cargo to triagebot

### DIFF
--- a/highfive/configs/rust-lang/cargo.json
+++ b/highfive/configs/rust-lang/cargo.json
@@ -1,7 +1,0 @@
-{
-    "groups": {
-        "all": ["@ehuss", "@epage", "@weihanglo"]
-    },
-    "contributing": "https://github.com/rust-lang/cargo/blob/master/CONTRIBUTING.md",
-    "new_pr_labels": ["S-waiting-on-review"]
-}


### PR DESCRIPTION
This migrates rust-lang/cargo to triagebot.