### PR TITLE
Migrate rust-lang/rust-by-example to triagebot

### DIFF
--- a/highfive/configs/rust-lang/rust-by-example.json
+++ b/highfive/configs/rust-lang/rust-by-example.json
@@ -1,7 +1,0 @@
-{
-    "groups": {
-        "all": ["@marioidival"]
-    },
-    "dirs": {
-    }
-}


### PR DESCRIPTION
This removes rust-lang/rust-by-example from highfive in preparation to transition to triagebot.