### PR TITLE
Migrate rust-lang/rust.vim to triagebot

### DIFF
--- a/highfive/configs/rust-lang/rust.vim.json
+++ b/highfive/configs/rust-lang/rust.vim.json
@@ -1,6 +1,0 @@
-{
-    "groups": {
-        "all": ["@chris-morgan", "@da-x"]
-    },
-    "dirs": {}
-}


### PR DESCRIPTION
This removes rust-lang/rust.vim from highfive in preparation to transition to triagebot.