### PR TITLE
Migrate rust-lang/stdarch to triagebot

### DIFF
--- a/highfive/configs/rust-lang/stdarch.json
+++ b/highfive/configs/rust-lang/stdarch.json
@@ -1,7 +1,0 @@
-{
-    "groups": {
-        "all": ["@Amanieu"]
-    },
-    "dirs": {
-    }
-}


### PR DESCRIPTION
This removes rust-lang/stdarch from highfive in preparation to transition to triagebot.